### PR TITLE
Fix Strand Sort implementation

### DIFF
--- a/Sorting/StrandSort.java
+++ b/Sorting/StrandSort.java
@@ -9,13 +9,14 @@
  public class StrandSort {
      public static List<Integer> strandSort(List<Integer> arr) {
          List<Integer> sortedList = new ArrayList<>();
-         while (!arr.isEmpty()) {
+         List<Integer> array = new ArrayList<>(arr);
+         while (!array.isEmpty()) {
              List<Integer> sublist = new ArrayList<>();
-             int first = arr.remove(0);
+             int first = array.remove(0);
              sublist.add(first);
  
              // Find the longest subsequence in increasing order
-             Iterator<Integer> iter = arr.iterator();
+             Iterator<Integer> iter = array.iterator();
              while (iter.hasNext()) {
                  int num = iter.next();
                  if (num >= sublist.get(sublist.size() - 1)) {
@@ -30,8 +31,9 @@
  
      public static void execute() {
          List<Integer> arr = Arrays.asList(5, 2, 9, 1, 5, 6);
+         System.out.println("Original Array:\n" + arr);
          List<Integer> sorted = strandSort(arr);
-         System.out.println(sorted);
+         System.out.println("Sorted Array:\n" + sorted);
      }
  }
  

--- a/Sorting/StrandSort.java
+++ b/Sorting/StrandSort.java
@@ -7,6 +7,26 @@
  import java.util.*;
 
  public class StrandSort {
+
+     public static List<Integer> merge(List<Integer> sortedList, List<Integer> sublist){
+         List<Integer> mergedList = new ArrayList<>();
+         int i = 0, j = 0;
+         // Merge the two lists
+         while (i < sortedList.size() && j < sublist.size()) {
+             if (sortedList.get(i) < sublist.get(j)) {
+                 mergedList.add(sortedList.get(i));
+                 i++;
+             } else {
+                 mergedList.add(sublist.get(j));
+                 j++;
+             }
+         }
+         // Add the remaining elements
+         mergedList.addAll(sortedList.subList(i, sortedList.size()));
+         mergedList.addAll(sublist.subList(j, sublist.size()));
+         return mergedList;
+     }
+
      public static List<Integer> strandSort(List<Integer> arr) {
          List<Integer> sortedList = new ArrayList<>();
          List<Integer> array = new ArrayList<>(arr);
@@ -24,7 +44,8 @@
                      iter.remove();
                  }
              }
-             sortedList.addAll(sublist);
+             // Merge subsequence into sorted list
+             sortedList = merge(sortedList, sublist);
          }
          return sortedList;
      }


### PR DESCRIPTION
Fixes issue described in #34:
- Fixes UnsupportedOperationException exception when calling strandSort method.
- Fixes sorting in StrandSort by adding merge method.

The exception that was caused by the program comes from this line `int first = arr.remove(0);` And its due to how the arr argument was declared and passed to the function.

If we look at the execute method, arr is declared as `List<Integer> arr = Arrays.asList(5, 2, 9, 1, 5, 6);` Looking at the documentation for the asList method, we can see that the methods that change the size of the list would throw this exception.

```java
The returned list implements the optional {@code Collection} methods, except
those that would change the size of the returned list. Those methods leave
the list unchanged and throw {@link UnsupportedOperationException}.
```

Since this method and algorithm modifies the orginal unsorted array multiple times, I believe an appropiate solution to solve this issue is to create a copy of this array and modify this copy instead of the original array. This way we prevent this exception from being raised and leave the original array unchanged.

While reviewing this issue, I also noticed that this strand algorithm does not perform the sort operation correctly, looking at the example provided with the user interface:

```
Original Array:
[5, 2, 9, 1, 5, 6]
Sorted Array:
[5, 9, 2, 5, 6, 1]
```

This error was due to how the implementation performed the merge operation by just simply appending the values of the sublit array into the sortedList array, without considering the values stored in each array. To fix this, I added a merge function to succesfully merge these two lists by making sure that its values are sorted.